### PR TITLE
Optional argument to only return data of a specific validator vote address

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,6 @@ Usage of solana_exporter:
         number for the log level verbosity
   -vmodule value
         comma-separated list of pattern=N settings for file-filtered logging
+  -votepubkey
+        Validator vote address (will only return results of this address)
 ```

--- a/cmd/solana_exporter/exporter.go
+++ b/cmd/solana_exporter/exporter.go
@@ -17,8 +17,9 @@ const (
 )
 
 var (
-	rpcAddr = flag.String("rpcURI", "", "Solana RPC URI (including protocol and path)")
-	addr    = flag.String("addr", ":8080", "Listen address")
+	rpcAddr     = flag.String("rpcURI", "", "Solana RPC URI (including protocol and path)")
+	addr        = flag.String("addr", ":8080", "Listen address")
+	votePubkey  = flag.String("votepubkey", "", "Validator vote address (will only return results of this address)")
 )
 
 func init() {
@@ -93,7 +94,12 @@ func (c *solanaCollector) Collect(ch chan<- prometheus.Metric) {
 	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
 	defer cancel()
 
-	accs, err := c.rpcClient.GetVoteAccounts(ctx, rpc.CommitmentRecent)
+	params := map[string]string{"commitment": string(rpc.CommitmentRecent)}
+	if *votePubkey != "" {
+		params = map[string]string{"commitment": string(rpc.CommitmentRecent), "votePubkey": *votePubkey}
+	}
+
+	accs, err := c.rpcClient.GetVoteAccounts(ctx, []interface{}{params})
 	if err != nil {
 		ch <- prometheus.NewInvalidMetric(c.totalValidatorsDesc, err)
 		ch <- prometheus.NewInvalidMetric(c.validatorActivatedStake, err)

--- a/pkg/rpc/validators.go
+++ b/pkg/rpc/validators.go
@@ -29,8 +29,8 @@ type (
 )
 
 // https://docs.solana.com/developing/clients/jsonrpc-api#getvoteaccounts
-func (c *RPCClient) GetVoteAccounts(ctx context.Context, commitment Commitment) (*GetVoteAccountsResponse, error) {
-	body, err := c.rpcRequest(ctx, formatRPCRequest("getVoteAccounts", []interface{}{commitment}))
+func (c *RPCClient) GetVoteAccounts(ctx context.Context, params []interface{}) (*GetVoteAccountsResponse, error) {
+	body, err := c.rpcRequest(ctx, formatRPCRequest("getVoteAccounts", params))
 	if err != nil {
 		return nil, fmt.Errorf("RPC call failed: %w", err)
 	}


### PR DESCRIPTION
Add of an optional `-votepubkey` argument to be able to only return data of the specified validator vote address.

It uses `getVoteAccounts`'s `votePubkey: <string>` optional parameter from the [JSON RPC API](https://docs.solana.com/developing/clients/jsonrpc-api#getvoteaccounts).

This was implemented in order to monitor a specific validator without having to export data from all validators, which can become quite expensive when using a platform like Grafana Cloud.
